### PR TITLE
Use the latest Fedora packages for this container now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,33 @@
-FROM fedora:31
-ENV PCP_REPO=https://github.com/performancecopilot/pcp.git
-ENV PCP_VERSION=46a90c589c998df294b15929a9392867c57659d8
-ENV GRAFANA_PCP_REPO=https://github.com/performancecopilot/grafana-pcp.git
-ENV GRAFANA_PCP_VERSION=4d3b907ff453f2f6a09c26322a1b5439b4e5d6e8
+FROM fedora:latest
 
-RUN dnf -y install \
-        pkg-config make gcc flex bison \
-        which sudo hostname findutils bc git cppcheck \
-        rpm-build redhat-rpm-config initscripts man procps \
-        avahi-devel ncurses-devel readline-devel zlib-devel \
-        perl perl-devel perl-generators perl-ExtUtils-MakeMaker \
-        python2-devel python3 python3-devel pylint \
-        bcc-tools bpftrace e2fsprogs xfsprogs libmicrohttpd-devel \
-        libuv-devel openssl-devel python2 \
-        nodejs-yarn
-
-WORKDIR /pcp
-RUN git clone ${PCP_REPO} . && git checkout ${PCP_VERSION}
-RUN sed 's@/bin/hostname@hostname@g' -i ./build/rpm/pcp.spec.in
-RUN ./Makepkgs --without-qt --without-qt3d --without-manager
-
-WORKDIR /grafana-pcp
-RUN git clone ${GRAFANA_PCP_REPO} . && git checkout ${GRAFANA_PCP_VERSION}
-RUN nodejs-yarn install && nodejs-yarn build
-
-
-FROM fedora:31
-COPY --from=0 /pcp/pcp-*/build/rpm /pcp-rpms
-COPY --from=0 /grafana-pcp/dist /var/lib/grafana/plugins/grafana-pcp
-COPY grafana-configuration.service /etc/systemd/system
-
-RUN dnf -y install dnf-plugins-core && \
-    dnf -y copr enable agerstmayr/bpftrace && \
-    dnf -y install \
-        kmod procps redis grafana bcc-tools bpftrace \
-        $(ls /pcp-rpms/*.{x86_64,noarch}.rpm) && \
+RUN dnf install -y --setopt=tsflags=nodocs \
+	redis grafana-pcp pcp-zeroconf \
+	pcp-pmda-bcc pcp-pmda-bpftrace \
+	kmod procps bcc-tools bpftrace \
+	&& \
     dnf clean all && \
-    touch /var/lib/pcp/pmdas/{bcc,bpftrace}/.NeedInstall && \
-    systemctl enable redis pmcd pmproxy grafana-server grafana-configuration
+    touch /var/lib/pcp/pmdas/{bcc,bpftrace}/.NeedInstall
 
 COPY grafana.ini /etc/grafana/grafana.ini
+COPY grafana-configuration.service /etc/systemd/system
 COPY datasource.yaml /usr/share/grafana/conf/provisioning/datasources/grafana-pcp.yaml
 COPY bpftrace.conf /var/lib/pcp/pmdas/bpftrace/bpftrace.conf
 
+RUN systemctl enable redis grafana-server grafana-configuration
+RUN systemctl enable pmcd pmie pmlogger pmproxy
+
+# PCP archives (auto-discovered by pmproxy), REST API, PCP port
+VOLUME ["/var/log/pcp/pmlogger"]
+EXPOSE 44322
+EXPOSE 44321
+
+# Redis RDB files and Redis RESP port
+VOLUME ["/var/lib/redis"]
+EXPOSE 6379
+
+# Grafana DB and REST API port
+VOLUME ["/var/lib/grafana"]
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/libexec/container-setup"]
 CMD ["/usr/sbin/init"]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/performancecopilot/pcp-preview/status "Docker Repository on Quay")](https://quay.io/repository/performancecopilot/pcp-preview)
 
-This container contains preview versions of upcoming Performance Co-Pilot features.
-It includes the following components:
+This container contains a preview of modern Performance Co-Pilot features
+as an all-in-one container.  It includes the following components:
 
 * [Performance Co-Pilot](https://pcp.io)
 * [grafana-pcp](https://github.com/performancecopilot/grafana-pcp) - PCP Plugin for Grafana
@@ -21,4 +21,7 @@ sudo -H podman run -d --privileged -v /lib/modules:/lib/modules:ro -v /usr/src:/
 sudo -H docker run -d --privileged -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -p 3000:3000 quay.io/performancecopilot/pcp-preview
 ```
 
+pmcd is ready at http://localhost:44321
+pmproxy is ready at http://localhost:44322
+Redis is ready at http://localhost:6379
 Grafana is ready at http://localhost:3000


### PR DESCRIPTION
Since all features previously being demo'd here are now
merged and part of Fedora, switch to using fedora:latest
and turn this into an all-in-one PCP, Redis and Grafana
preview container tracking latest Fedora versions.